### PR TITLE
feat(KSSwiperContainer): Add callback for when swiper is initialized

### DIFF
--- a/src/ks-swiper.ts
+++ b/src/ks-swiper.ts
@@ -1,6 +1,6 @@
 declare var require;
 
-import {Injectable, Inject, Component, ElementRef, Host, Input} from '@angular/core';
+import {Injectable, Inject, Component, ElementRef, EventEmitter, Host, Input, Output} from '@angular/core';
 
 // import Swiper from 'swiper';
 const Swiper = require('swiper');
@@ -34,6 +34,8 @@ export class KSSwiperContainer {
 
   @Input() options: any;
 
+  @Output() swiperInitialized: EventEmitter<Swiper> = new EventEmitter<Swiper>();
+
   // the underlying swiper instance
   // TODO: do not have typedefinitions yet
   // so using any
@@ -53,6 +55,7 @@ export class KSSwiperContainer {
     const nativeElement = this.elementRef.nativeElement;
     setTimeout(() => {
       this.swiper = new Swiper(nativeElement.children[0], this.options);
+      this.swiperInitialized.emit(swiper);
     });
   }
 


### PR DESCRIPTION
It would be very nice to emit an event when swiper is initialized, as using the lifecycle events such as `ngAfterInit` aren't reliable as a result of the timeout. This would allow the registration of event listeners on swiper once it was initialized.